### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^\.ccache$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/common-name.R
+++ b/R/common-name.R
@@ -10,7 +10,9 @@
 fbc_common_name <- function(x) {
   stopifnot(is.vector(x, "character"))
 
-  if(!length(x)) return(character(0))
+  if (!length(x)) {
+    return(character(0))
+  }
 
   y <- fishbc::freshwaterfish$CommonName
   names(y) <- fishbc::freshwaterfish$Code

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/data-raw/data-raw.R
+++ b/data-raw/data-raw.R
@@ -2,14 +2,27 @@ library(readr)
 
 cdc <- readr::read_csv("data-raw/cdc/cdc.csv")
 freshwaterfish <- readr::read_csv("data-raw/freshwaterfish/freshwaterfish.csv")
-whse_fish_species_cd <- readr::read_csv("data-raw/whse_fish_species_cd/whse_fish_species_cd.csv")
-ab <- readxl::read_excel("data-raw/ab/ep-fwmis-fisheries-loadform.xls", sheet = 11)
+whse_fish_species_cd <- readr::read_csv(
+  "data-raw/whse_fish_species_cd/whse_fish_species_cd.csv"
+)
+ab <- readxl::read_excel(
+  "data-raw/ab/ep-fwmis-fisheries-loadform.xls",
+  sheet = 11
+)
 
-freshwaterfish <- freshwaterfish[order(freshwaterfish$Class, freshwaterfish$Order, freshwaterfish$Family,
-  freshwaterfish$Genus, freshwaterfish$Species, freshwaterfish$Subspecies,
-  freshwaterfish$Species2, freshwaterfish$Code,
-  na.last = FALSE
-), ]
+freshwaterfish <- freshwaterfish[
+  order(
+    freshwaterfish$Class,
+    freshwaterfish$Order,
+    freshwaterfish$Family,
+    freshwaterfish$Genus,
+    freshwaterfish$Species,
+    freshwaterfish$Subspecies,
+    freshwaterfish$Species2,
+    freshwaterfish$Code,
+    na.last = FALSE
+  ),
+]
 
 whse_fish_species_cd$SPECIES_ID <- as.integer(whse_fish_species_cd$SPECIES_ID)
 
@@ -21,8 +34,16 @@ chk::check_key(cdc, "Species Code")
 chk::check_key(ab, "Species Code")
 chk::check_key(whse_fish_species_cd, "CODE")
 
-chk::chk_join(freshwaterfish[!is.na(freshwaterfish$ABCode),], ab, by = c("ABCode" = "Species Code"))
-chk::chk_join(freshwaterfish[!is.na(freshwaterfish$CDCode),], cdc, by = c("CDCode" = "Species Code"))
+chk::chk_join(
+  freshwaterfish[!is.na(freshwaterfish$ABCode), ],
+  ab,
+  by = c("ABCode" = "Species Code")
+)
+chk::chk_join(
+  freshwaterfish[!is.na(freshwaterfish$CDCode), ],
+  cdc,
+  by = c("CDCode" = "Species Code")
+)
 
 usethis::use_data(cdc, overwrite = TRUE)
 usethis::use_data(freshwaterfish, overwrite = TRUE)

--- a/tests/testthat/test-common-name.R
+++ b/tests/testthat/test-common-name.R
@@ -4,6 +4,8 @@ test_that("common_name", {
   expect_error(fbc_common_name(factor("AF")))
   expect_identical(fbc_common_name("AF"), "All Fish")
   expect_identical(fbc_common_name("A"), NA_character_)
-  expect_identical(fbc_common_name(c("AF", "WSG", NA, "AF", "NOTACODE")),
-                   c("All Fish", "White Sturgeon", NA, "All Fish", NA))
+  expect_identical(
+    fbc_common_name(c("AF", "WSG", NA, "AF", "NOTACODE")),
+    c("All Fish", "White Sturgeon", NA, "All Fish", NA)
+  )
 })

--- a/tests/testthat/test-freshwaterfish.R
+++ b/tests/testthat/test-freshwaterfish.R
@@ -2,7 +2,6 @@ test_that("freshwaterfish", {
   skip_if_not_installed("chk")
   skip_if_not_installed("tibble")
 
-
   expect_true(chk::vld_data(freshwaterfish))
 
   expect_snapshot({
@@ -12,11 +11,22 @@ test_that("freshwaterfish", {
   expect_true(chk::vld_identical(
     colnames(freshwaterfish),
     c(
-      "Code", "CommonName", "Class", "Order",
-      "Family", "Genus",
-      "Species", "Subspecies", "Species2", "Extant",
+      "Code",
+      "CommonName",
+      "Class",
+      "Order",
+      "Family",
+      "Genus",
+      "Species",
+      "Subspecies",
+      "Species2",
+      "Extant",
       "Native",
-      "Marine", "Yellow", "Blue", "Red", "CDCode",
+      "Marine",
+      "Yellow",
+      "Blue",
+      "Red",
+      "CDCode",
       "ABCode"
     )
   ))
@@ -33,21 +43,80 @@ test_that("freshwaterfish", {
   expect_true(chk::vld_unique(freshwaterfish$Code))
   expect_true(chk::vld_unique(freshwaterfish$CommonName))
 
-  expect_true(all(freshwaterfish$Native | (!freshwaterfish$Yellow & !freshwaterfish$Blue & !freshwaterfish$Red)))
-  expect_true(all(freshwaterfish$Extant | (!freshwaterfish$Yellow & !freshwaterfish$Blue & !freshwaterfish$Red)))
+  expect_true(all(
+    freshwaterfish$Native |
+      (!freshwaterfish$Yellow & !freshwaterfish$Blue & !freshwaterfish$Red)
+  ))
+  expect_true(all(
+    freshwaterfish$Extant |
+      (!freshwaterfish$Yellow & !freshwaterfish$Blue & !freshwaterfish$Red)
+  ))
 
-  expect_true(all(ifelse(!is.na(freshwaterfish$Species2), !is.na(freshwaterfish$Species), TRUE)))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Species2),
+    !is.na(freshwaterfish$Species),
+    TRUE
+  )))
 
-  expect_true(all(ifelse(!is.na(freshwaterfish$Subspecies), !is.na(freshwaterfish$Species), TRUE)))
-  expect_true(all(ifelse(!is.na(freshwaterfish$Species), !is.na(freshwaterfish$Genus), TRUE)))
-  expect_true(all(ifelse(!is.na(freshwaterfish$Genus), !is.na(freshwaterfish$Family), TRUE)))
-  expect_true(all(ifelse(!is.na(freshwaterfish$Family), !is.na(freshwaterfish$Order), TRUE)))
-  expect_true(all(ifelse(!is.na(freshwaterfish$Order), !is.na(freshwaterfish$Class), TRUE)))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Subspecies),
+    !is.na(freshwaterfish$Species),
+    TRUE
+  )))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Species),
+    !is.na(freshwaterfish$Genus),
+    TRUE
+  )))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Genus),
+    !is.na(freshwaterfish$Family),
+    TRUE
+  )))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Family),
+    !is.na(freshwaterfish$Order),
+    TRUE
+  )))
+  expect_true(all(ifelse(
+    !is.na(freshwaterfish$Order),
+    !is.na(freshwaterfish$Class),
+    TRUE
+  )))
 
-  expect_true(!anyDuplicated(unique(freshwaterfish[!is.na(freshwaterfish$Genus), c("Family", "Genus")])$Genus))
-  expect_true(!anyDuplicated(unique(freshwaterfish[!is.na(freshwaterfish$Family), c("Order", "Family")])$Family))
-  expect_true(!anyDuplicated(unique(freshwaterfish[!is.na(freshwaterfish$Order), c("Class", "Order")])$Order))
+  expect_true(
+    !anyDuplicated(
+      unique(freshwaterfish[
+        !is.na(freshwaterfish$Genus),
+        c("Family", "Genus")
+      ])$Genus
+    )
+  )
+  expect_true(
+    !anyDuplicated(
+      unique(freshwaterfish[
+        !is.na(freshwaterfish$Family),
+        c("Order", "Family")
+      ])$Family
+    )
+  )
+  expect_true(
+    !anyDuplicated(
+      unique(freshwaterfish[
+        !is.na(freshwaterfish$Order),
+        c("Class", "Order")
+      ])$Order
+    )
+  )
 
-  expect_true(chk::vld_data(chk::chk_join(freshwaterfish[!is.na(freshwaterfish$ABCode),], ab, by = c("ABCode" = "Species Code"))))
-  expect_true(chk::vld_data(chk::chk_join(freshwaterfish[!is.na(freshwaterfish$CDCode),], cdc, by = c("CDCode" = "Species Code"))))
+  expect_true(chk::vld_data(chk::chk_join(
+    freshwaterfish[!is.na(freshwaterfish$ABCode), ],
+    ab,
+    by = c("ABCode" = "Species Code")
+  )))
+  expect_true(chk::vld_data(chk::chk_join(
+    freshwaterfish[!is.na(freshwaterfish$CDCode), ],
+    cdc,
+    by = c("CDCode" = "Species Code")
+  )))
 })

--- a/tests/testthat/test-whse_fish_species_cd.R
+++ b/tests/testthat/test-whse_fish_species_cd.R
@@ -2,23 +2,31 @@ test_that("whse_fish_species_cd", {
   skip_if_not_installed("chk")
   skip_if_not_installed("tibble")
 
-  expect_error(chk::check_data(
-    fishbc:::whse_fish_species_cd,
-    values = list(SPECIES_ID = c(1L, 192L),
-                  CODE = "",
-                  NAME = "",
-                  CDCGR_CODE = c("", NA),
-                  CDCLR_CODE = c("", NA),
-                  SCIENTIFIC_NAME = c("", NA),
-                  SPCTYPE_CODE = "",
-                  SPCGRP_CODE = c("", NA)
-                  ),
-    nrow = 192,
-    key = "SPECIES_ID"), NA)
+  expect_error(
+    chk::check_data(
+      fishbc:::whse_fish_species_cd,
+      values = list(
+        SPECIES_ID = c(1L, 192L),
+        CODE = "",
+        NAME = "",
+        CDCGR_CODE = c("", NA),
+        CDCLR_CODE = c("", NA),
+        SCIENTIFIC_NAME = c("", NA),
+        SPCTYPE_CODE = "",
+        SPCGRP_CODE = c("", NA)
+      ),
+      nrow = 192,
+      key = "SPECIES_ID"
+    ),
+    NA
+  )
 
   chk::check_key(fishbc:::whse_fish_species_cd, "CODE")
   chk::check_key(fishbc:::whse_fish_species_cd, "NAME")
 
-  chk::chk_join(fishbc::freshwaterfish, fishbc:::whse_fish_species_cd,
-                by = c(Code = "CODE"))
+  chk::chk_join(
+    fishbc::freshwaterfish,
+    fishbc:::whse_fish_species_cd,
+    by = c(Code = "CODE")
+  )
 })


### PR DESCRIPTION
Closes #47

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)